### PR TITLE
Updated the "bundle" of the "option" argument of the "emit" function.

### DIFF
--- a/server.tsx
+++ b/server.tsx
@@ -6,7 +6,7 @@ import Comments from './components/Comments.tsx'
 import { Hello } from './components/Hello.tsx'
 
 const { files } = await Deno.emit('./client.tsx', {
-  bundle: 'esm',
+  bundle: 'module',
   compilerOptions: {
     jsxFactory: 'h',
     target: 'es2015',


### PR DESCRIPTION
Because it doesn't work with deno version 1.15.2 .
> esm -> module